### PR TITLE
feat: extend todo app with tag filtering and undo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+/dist
+.env
+.DS_Store
+
+# Vite local state
+*.local

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ToDo App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "test-obsidian",
+  "version": "1.0.0",
+  "description": "ToDo app using Vite, React, TypeScript, and Zustand.",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "echo \"No lint configured\"",
+    "test": "echo \"No test configured\""
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.5.0",
+    "nanoid": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,12 @@
+import { TodoForm } from './components/TodoForm';
+import { TodoList } from './components/TodoList';
+
+export default function App() {
+  return (
+    <div>
+      <h1>ToDo App</h1>
+      <TodoForm />
+      <TodoList />
+    </div>
+  );
+}

--- a/src/components/TodoForm.tsx
+++ b/src/components/TodoForm.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { useTodoStore } from '../store';
+import type { Priority } from '../types';
+
+interface Props {
+  id?: string;
+  initial?: {
+    title: string;
+    description?: string;
+    dueDate?: string;
+    priority: Priority;
+    tags: string[];
+  };
+  onSubmit?: () => void;
+}
+
+export function TodoForm({ id, initial, onSubmit }: Props) {
+  const add = useTodoStore((s) => s.add);
+  const update = useTodoStore((s) => s.update);
+  const [title, setTitle] = useState(initial?.title ?? '');
+  const [description, setDescription] = useState(initial?.description ?? '');
+  const [dueDate, setDueDate] = useState(initial?.dueDate ?? '');
+  const [priority, setPriority] = useState<Priority>(initial?.priority ?? 'medium');
+  const [tags, setTags] = useState((initial?.tags ?? []).join(','));
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const data = {
+      title,
+      description,
+      dueDate,
+      priority,
+      tags: tags
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean),
+    };
+    if (id) {
+      update(id, data);
+      onSubmit?.();
+    } else {
+      add(data);
+      setTitle('');
+      setDescription('');
+      setDueDate('');
+      setPriority('medium');
+      setTags('');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} aria-label="todo form">
+      <label>
+        Title
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+        />
+      </label>
+      <label>
+        Description
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </label>
+      <label>
+        Due Date
+        <input
+          type="date"
+          value={dueDate}
+          onChange={(e) => setDueDate(e.target.value)}
+        />
+      </label>
+      <label>
+        Priority
+        <select
+          value={priority}
+          onChange={(e) => setPriority(e.target.value as Priority)}
+        >
+          <option value="low">Low</option>
+          <option value="medium">Medium</option>
+          <option value="high">High</option>
+        </select>
+      </label>
+      <label>
+        Tags
+        <input
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+          placeholder="tag1,tag2"
+        />
+      </label>
+      <button type="submit">{id ? 'Update' : 'Add'}</button>
+    </form>
+  );
+}

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import type { Todo } from '../types';
+import { useTodoStore } from '../store';
+import { TodoForm } from './TodoForm';
+
+interface Props {
+  todo: Todo;
+}
+
+export function TodoItem({ todo }: Props) {
+  const toggle = useTodoStore((s) => s.toggle);
+  const remove = useTodoStore((s) => s.remove);
+  const toggleSelect = useTodoStore((s) => s.toggleSelect);
+  const isSelected = useTodoStore((s) => s.selected.has(todo.id));
+  const [editing, setEditing] = useState(false);
+
+  if (editing) {
+    return (
+      <TodoForm
+        id={todo.id}
+        initial={todo}
+        onSubmit={() => setEditing(false)}
+      />
+    );
+  }
+
+  return (
+    <div>
+      <input
+        type="checkbox"
+        checked={isSelected}
+        onChange={() => toggleSelect(todo.id)}
+        aria-label="select todo"
+      />
+      <input
+        type="checkbox"
+        checked={todo.completed}
+        onChange={() => toggle(todo.id)}
+        aria-label="toggle complete"
+      />
+      <span>{todo.title}</span>
+      {todo.dueDate && <span> (due: {todo.dueDate})</span>}
+      <span> [{todo.priority}]</span>
+      {todo.tags.length > 0 && <span> {todo.tags.join(', ')}</span>}
+      <button onClick={() => setEditing(true)}>Edit</button>
+      <button onClick={() => remove(todo.id)}>Delete</button>
+    </div>
+  );
+}

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -1,0 +1,103 @@
+import { useState, useRef, useEffect } from 'react';
+import { useTodoStore } from '../store';
+import { TodoItem } from './TodoItem';
+
+type Filter = 'all' | 'active' | 'completed';
+type Sort = 'created' | 'due' | 'priority';
+
+export function TodoList() {
+  const todos = useTodoStore((s) => s.todos);
+  const completeSelected = useTodoStore((s) => s.completeSelected);
+  const removeSelected = useTodoStore((s) => s.removeSelected);
+  const clearSelection = useTodoStore((s) => s.clearSelection);
+  const lastDeleted = useTodoStore((s) => s.lastDeleted);
+  const undoRemove = useTodoStore((s) => s.undoRemove);
+
+  const [filter, setFilter] = useState<Filter>('all');
+  const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<Sort>('created');
+  const [tag, setTag] = useState('');
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const tags = Array.from(new Set(todos.flatMap((t) => t.tags)));
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        searchRef.current?.focus();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  const filtered = todos
+    .filter((t) => {
+      if (filter === 'active') return !t.completed;
+      if (filter === 'completed') return t.completed;
+      return true;
+    })
+    .filter((t) => {
+      const text = `${t.title} ${t.description}`.toLowerCase();
+      return text.includes(search.toLowerCase());
+    })
+    .filter((t) => (tag ? t.tags.includes(tag) : true))
+    .sort((a, b) => {
+      if (sort === 'created') return a.createdAt.localeCompare(b.createdAt);
+      if (sort === 'due') return (a.dueDate || '').localeCompare(b.dueDate || '');
+      if (sort === 'priority') {
+        const order: Record<string, number> = { low: 0, medium: 1, high: 2 };
+        return order[a.priority] - order[b.priority];
+      }
+      return 0;
+    });
+
+  return (
+    <div>
+      <div>
+        <button onClick={() => setFilter('all')}>All</button>
+        <button onClick={() => setFilter('active')}>Active</button>
+        <button onClick={() => setFilter('completed')}>Completed</button>
+      </div>
+      <input
+        ref={searchRef}
+        placeholder="Search..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        aria-label="search todo"
+      />
+      <select value={sort} onChange={(e) => setSort(e.target.value as Sort)}>
+        <option value="created">Created</option>
+        <option value="due">Due Date</option>
+        <option value="priority">Priority</option>
+      </select>
+      <select value={tag} onChange={(e) => setTag(e.target.value)}>
+        <option value="">All Tags</option>
+        {tags.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+      <div>
+        {filtered.length === 0 ? (
+          <p>No todos</p>
+        ) : (
+          filtered.map((todo) => <TodoItem key={todo.id} todo={todo} />)
+        )}
+      </div>
+      <div>
+        <button onClick={completeSelected}>Complete Selected</button>
+        <button onClick={removeSelected}>Delete Selected</button>
+        <button onClick={clearSelection}>Clear Selection</button>
+      </div>
+      {lastDeleted && (
+        <div role="alert">
+          <span>Todo deleted.</span>
+          <button onClick={undoRemove}>Undo</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,106 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { nanoid } from 'nanoid';
+import type { Todo } from './types';
+
+interface TodoState {
+  todos: Todo[];
+  selected: Set<string>;
+  lastDeleted: Todo | null;
+  add: (todo: Omit<Todo, 'id' | 'createdAt' | 'updatedAt' | 'completed'>) => void;
+  update: (id: string, todo: Partial<Omit<Todo, 'id'>>) => void;
+  toggle: (id: string) => void;
+  remove: (id: string) => void;
+  undoRemove: () => void;
+  toggleSelect: (id: string) => void;
+  clearSelection: () => void;
+  completeSelected: () => void;
+  removeSelected: () => void;
+}
+
+function toISO(date: Date = new Date()) {
+  return date.toISOString();
+}
+
+export const useTodoStore = create<TodoState>()(
+  persist(
+    (set, get) => ({
+      todos: [],
+      selected: new Set(),
+      lastDeleted: null,
+      add: (data) =>
+        set((state) => ({
+          todos: [
+            ...state.todos,
+            {
+              ...data,
+              id: nanoid(),
+              completed: false,
+              createdAt: toISO(),
+              updatedAt: toISO(),
+            },
+          ],
+        })),
+      update: (id, data) =>
+        set((state) => ({
+          todos: state.todos.map((t) =>
+            t.id === id ? { ...t, ...data, updatedAt: toISO() } : t
+          ),
+        })),
+      toggle: (id) =>
+        set((state) => ({
+          todos: state.todos.map((t) =>
+            t.id === id
+              ? { ...t, completed: !t.completed, updatedAt: toISO() }
+              : t
+          ),
+        })),
+      remove: (id) =>
+        set((state) => {
+          const removed = state.todos.find((t) => t.id === id) || null;
+          window.setTimeout(() => set({ lastDeleted: null }), 5000);
+          return {
+            todos: state.todos.filter((t) => t.id !== id),
+            selected: new Set([...state.selected].filter((s) => s !== id)),
+            lastDeleted: removed,
+          };
+        }),
+      undoRemove: () =>
+        set((state) =>
+          state.lastDeleted
+            ? {
+                todos: [...state.todos, state.lastDeleted],
+                lastDeleted: null,
+              }
+            : {}
+        ),
+      toggleSelect: (id) =>
+        set((state) => {
+          const selected = new Set(state.selected);
+          selected.has(id) ? selected.delete(id) : selected.add(id);
+          return { selected };
+        }),
+      clearSelection: () => set({ selected: new Set() }),
+      completeSelected: () =>
+        set((state) => ({
+          todos: state.todos.map((t) =>
+            state.selected.has(t.id) ? { ...t, completed: true } : t
+          ),
+          selected: new Set(),
+        })),
+      removeSelected: () =>
+        set((state) => ({
+          todos: state.todos.filter((t) => !state.selected.has(t.id)),
+          selected: new Set(),
+        })),
+    }),
+    {
+      name: 'todo-store',
+      partialize: (state) => ({ todos: state.todos, selected: state.selected }),
+      serialize: {
+        replacer: (_key, value) => (value instanceof Set ? [...value] : value),
+        reviver: (key, value) => (key === 'selected' ? new Set(value) : value),
+      },
+    }
+  )
+);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,13 @@
+export type Priority = 'low' | 'medium' | 'high';
+
+export interface Todo {
+  id: string;
+  title: string;
+  description?: string;
+  dueDate?: string;
+  priority: Priority;
+  tags: string[];
+  completed: boolean;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add undo feature for deletions with five-second window
- support tag-based filtering and search shortcut (Ctrl/Cmd+K)
- improve form accessibility with labels and show todo metadata

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Cannot find module '@types/react', install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68afbd4b0d28832e8a512331bdc93214